### PR TITLE
Fixed to include all dependent classes in to jar file.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,7 +199,6 @@
     <dependency>
       <groupId>net.imagej</groupId>
       <artifactId>ij</artifactId><!--$NO-MVN-MAN-VER$-->
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>sc.fiji</groupId>
@@ -209,39 +208,34 @@
       <groupId>sc.fiji</groupId>
       <artifactId>3D_Viewer</artifactId>
       <version>4.0.1</version><!--$NO-MVN-MAN-VER$-->
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.scijava</groupId>
       <artifactId>j3dcore</artifactId>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.scijava</groupId>
       <artifactId>j3dutils</artifactId>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.scijava</groupId>
       <artifactId>vecmath</artifactId>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>sc.fiji</groupId>
       <artifactId>VIB-lib</artifactId>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.sbml.jsbml</groupId>
       <artifactId>jsbml-core</artifactId>
       <version>${jsbml.version}</version>
     </dependency>
-    
+
     <dependency>
-			<groupId>info.picocli</groupId>
-			<artifactId>picocli</artifactId>
-			<version>4.5.0</version>
-		</dependency>
+      <groupId>info.picocli</groupId>
+      <artifactId>picocli</artifactId>
+      <version>4.5.0</version>
+    </dependency>
 
     <dependency>
       <groupId>org.sbml.jsbml.ext</groupId>


### PR DESCRIPTION
Fixed to include all dependent classes in to jar file. confirmed to work with following command line: 
```sh
java -cp Xito_SBML-1.2.0-jar-with-dependencies.jar jp.ac.keio.bio.fun.xitosbml.cli.CLI_Filetype -i=image -o=foo -n=1 -d=bar/" 
```
where image1.tif file is stored under bar directory.